### PR TITLE
fix test to use consistent feature flag name for safe type expansion

### DIFF
--- a/tests/unit/adapters/mssql/test_can_expand_to.py
+++ b/tests/unit/adapters/mssql/test_can_expand_to.py
@@ -44,7 +44,5 @@ def test_can_expand_parametrized(src_kwargs, tgt_kwargs, expect_with_flag, expec
     src = SQLServerColumn(**src_kwargs)
     tgt = SQLServerColumn(**tgt_kwargs)
 
-    assert src.can_expand_to(tgt, sqlserver__enable_safe_type_expansion=True) is expect_with_flag
-    assert (
-        src.can_expand_to(tgt, sqlserver__enable_safe_type_expansion=False) is expect_without_flag
-    )
+    assert src.can_expand_to(tgt, enable_safe_type_expansion=True) is expect_with_flag
+    assert src.can_expand_to(tgt, enable_safe_type_expansion=False) is expect_without_flag


### PR DESCRIPTION
sqlserver__enable_safe_type_expansion to enable_safe_type_expansion on param