### PR TITLE
Enhance SQLServerColumn to support fixed numeric types and update tests

### DIFF
--- a/dbt/adapters/sqlserver/sqlserver_column.py
+++ b/dbt/adapters/sqlserver/sqlserver_column.py
@@ -76,7 +76,9 @@ class SQLServerColumn(Column):
         return self.dtype.lower() in ["varchar", "char", "nvarchar", "nchar"]
 
     def is_number(self):
-        return any([self.is_integer(), self.is_numeric(), self.is_float()])
+        return any(
+            [self.is_integer(), self.is_numeric(), self.is_float(), self.is_fixed_numeric()]
+        )
 
     def is_float(self):
         return self.dtype.lower() in ["float", "real"]
@@ -87,7 +89,10 @@ class SQLServerColumn(Column):
         return self.dtype.lower() in ["int", "integer", "bigint", "smallint", "tinyint", "bit"]
 
     def is_numeric(self) -> bool:
-        return self.dtype.lower() in ["numeric", "decimal", "money", "smallmoney"]
+        return self.dtype.lower() in ["numeric", "decimal"]
+
+    def is_fixed_numeric(self) -> bool:
+        return self.dtype.lower() in ["money", "smallmoney"]
 
     def string_size(self) -> int:
         if not self.is_string():
@@ -142,13 +147,15 @@ class SQLServerColumn(Column):
 
         # Numeric/Decimal promotions: allow when target precision >= source precision
         # and target scale >= source scale (so we don't lose fractional digits).
-        if self.is_numeric() and other_column.is_numeric():
+        if (self.is_numeric() or self.is_fixed_numeric()) and (
+            other_column.is_numeric() or other_column.is_fixed_numeric()
+        ):
             # Access precision/scale directly from columns. Fall back to 0 when missing.
             self_scale = int(self.numeric_scale or 0)
             other_scale = int(other_column.numeric_scale or 0)
 
             if other_prec >= self_prec and other_scale >= self_scale:
-                if other_prec > self_prec or other_scale > self_scale:
+                if other_prec > self_prec or other_scale > self_scale or self_dtype != other_dtype:
                     return True
 
         return False

--- a/tests/unit/adapters/mssql/test_can_expand_to.py
+++ b/tests/unit/adapters/mssql/test_can_expand_to.py
@@ -38,6 +38,44 @@ def col_kwargs(dtype, char_size=None, numeric_precision=0, numeric_scale=0):
         # String family change (VARCHAR -> NVARCHAR) is only allowed when the
         # feature flag is set and capacity is sufficient
         (col_kwargs("varchar", char_size=10), col_kwargs("nvarchar", char_size=10), True, False),
+        # Fixed-money types (MONEY/SMALLMONEY) behaviour
+        # SMALLMONEY -> MONEY (widening) requires the feature flag
+        (
+            col_kwargs("smallmoney", numeric_precision=10, numeric_scale=4),
+            col_kwargs("money", numeric_precision=19, numeric_scale=4),
+            True,
+            False,
+        ),
+        # MONEY -> NUMERIC with larger precision/scale should be allowed
+        (
+            col_kwargs("money", numeric_precision=19, numeric_scale=4),
+            col_kwargs("numeric", numeric_precision=20, numeric_scale=4),
+            True,
+            False,
+        ),
+        # SMALLMONEY -> NUMERIC with larger precision/scale should be allowed
+        (
+            col_kwargs("smallmoney", numeric_precision=10, numeric_scale=4),
+            col_kwargs("numeric", numeric_precision=20, numeric_scale=4),
+            True,
+            False,
+        ),
+        # Equal precision/scale between MONEY and NUMERIC is considered an
+        # expansion when the dtype changes (money -> numeric) under the
+        # feature flag
+        (
+            col_kwargs("money", numeric_precision=19, numeric_scale=4),
+            col_kwargs("numeric", numeric_precision=19, numeric_scale=4),
+            True,
+            False,
+        ),
+        # NUMERIC -> MONEY that would shrink precision should not be allowed
+        (
+            col_kwargs("numeric", numeric_precision=20, numeric_scale=4),
+            col_kwargs("money", numeric_precision=19, numeric_scale=4),
+            False,
+            False,
+        ),
     ],
 )
 def test_can_expand_parametrized(src_kwargs, tgt_kwargs, expect_with_flag, expect_without_flag):


### PR DESCRIPTION
This pull request enhances type handling and expansion logic for SQL Server columns, particularly around money-related types. The main changes include introducing a dedicated method for fixed-money types, refining numeric type checks, and updating the logic for type expansion to handle money and smallmoney types more accurately. The test suite is also expanded to cover these new scenarios.

**Type handling improvements:**

* Added a new method `is_fixed_numeric` to `sqlserver_column.py` to distinguish fixed-money types (`money`, `smallmoney`) from other numeric types.
* Updated `is_number` to include fixed-money types in its check, improving overall numeric type detection.
* Refined `is_numeric` to only match `numeric` and `decimal`, separating out money types for clearer logic.

**Type expansion logic:**

* Modified the `can_expand_to` method to allow expansion between numeric and fixed-money types, and to consider dtype changes as expansions when precision/scale are equal.

**Test coverage:**

* Added multiple new test cases to `test_can_expand_to.py` to verify correct behavior for money, smallmoney, and numeric type expansions, including scenarios with and without feature flags.